### PR TITLE
Cloudflare Images 의 example worker 세팅

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,59 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+interface CfImageOptions {
+	width?: number;
+	format?: 'avif' | 'webp';
+}
+
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		const url = new URL(request.url);
-		const query = url.searchParams.get("ab")
+		// const url = new URL(request.url);
 
-		return new Response('Hello World! ' + url.pathname + query);
+		// const query = url.searchParams.get('ab');
+
+		// return new Response('Hello World! ' + url.pathname + query);
+
+		let url = new URL(request.url);
+
+		let options: { cf: { image: CfImageOptions } } = { cf: { image: {} } };
+
+		const widthParam = url.searchParams.get('width');
+		if (widthParam) {
+			const width = parseInt(widthParam, 10);
+			if (!isNaN(width)) {
+				options.cf.image.width = width;
+			}
+		}
+
+		const accept = request.headers.get('Accept') ?? '';
+		if (/image\/avif/.test(accept)) {
+			options.cf.image.format = 'avif';
+		} else if (/image\/webp/.test(accept)) {
+			options.cf.image.format = 'webp';
+		}
+
+		const imageURL = url.searchParams.get('image');
+		if (!imageURL) return new Response('Missing "image" value', { status: 400 });
+
+		try {
+			const { hostname, pathname } = new URL(imageURL);
+
+			if (!/\.(jpe?g|png|gif|webp)$/i.test(pathname)) {
+				return new Response('Disallowed file extension', { status: 400 });
+			}
+
+			if (hostname !== 'makers-web-img.s3.ap-northeast-2.amazonaws.com') {
+				return new Response('Must use "example.com" source images', { status: 403 });
+			}
+		} catch (err) {
+			return new Response('Invalid "image" value', { status: 400 });
+		}
+
+		const imageRequest = new Request(imageURL, {
+			headers: request.headers,
+		});
+
+		return fetch(imageRequest, options);
 	},
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
https://developers.cloudflare.com/images/transform-images/transform-via-workers/#warning-about-cachekey

Cloudflare Images 문서에 있는, example worker 세팅을 해두었습니다.

- [x]  export default 방식으로 export 방식을 변경하였습니다.
- [x]  javascript > typescript 로 변경하였습니다.
- [x]  패키지 매니저로, pnpm 을 사용하였습니다.
- [x]  deploy-worker 명령어를 이용해 배포를 진행합니다. 깃허브 CI 는 구현하지 않았습니다. 혹시 배포가 필요하면 저에게 말씀주세요 :)