### PR TITLE
feat: blur 옵션을 추가합니다.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,6 @@ export default {
 			headers: request.headers,
 		});
 
-		console.log(options);
-
 		return fetch(imageRequest, options);
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
 interface CfImageOptions {
 	width?: number;
 	format?: 'avif' | 'webp';
+	blur?: number;
 }
 
 export default {
@@ -33,6 +34,14 @@ export default {
 			const width = parseInt(widthParam, 10);
 			if (!isNaN(width)) {
 				options.cf.image.width = width;
+			}
+		}
+
+		const blurParam = url.searchParams.get('blur');
+		if (blurParam) {
+			const blur = parseInt(blurParam, 10);
+			if (!isNaN(blur) && blur >= 1 && blur <= 250) {
+				options.cf.image.blur = blur;
 			}
 		}
 
@@ -63,6 +72,8 @@ export default {
 		const imageRequest = new Request(imageURL, {
 			headers: request.headers,
 		});
+
+		console.log(options);
 
 		return fetch(imageRequest, options);
 	},


### PR DESCRIPTION
close #3 

이미지가 완전히 로드되기 전에 블러처리된 이미지를 보여주는 기능인 `blur` 옵션을 추가했어요.
https://developers.cloudflare.com/images/transform-images/transform-via-workers/#blur

공식문서에서 `blur`의 유효 범위를 1 이상 250 이하로 정의하고 있으므로 조건문에서 이를 검사해주도록 했어요.

```ts
const blurParam = url.searchParams.get('blur');
if (blurParam) {
	const blur = parseInt(blurParam, 10);
	if (!isNaN(blur) && blur >= 1 && blur <= 250) {
		options.cf.image.blur = blur;
	}
}
```

로컬에서 다음과 같이 쿼리파라미터를 실어 보냈을 때 정상적으로 파라미터 값이 `image` 객체 내부 필드에 실리는 것을 확인했어요.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/90ca9c5f-cbfa-42e2-93d5-27beddd20748">

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8298741a-9158-4fdb-99c5-ed30ecd6264b">




